### PR TITLE
Fix for the 25-result limit per page...

### DIFF
--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -569,7 +569,7 @@ class RdsResultStorage extends \tao_models_classes_GenerisService
         if(isset($options['offset']) || isset($options['limit'])){
             $offset = (isset($options['offset']))?$options['offset']:0;
             $limit = (isset($options['limit']))?$options['limit']:1000;
-            $this->persistence->getPlatForm()->limitStatement($sql, $limit, $offset);
+            $sql = $this->persistence->getPlatForm()->limitStatement($sql, $limit, $offset);
         }
         $results = $this->persistence->query($sql, $params);
         foreach ($results as $value) {


### PR DESCRIPTION
...reported by O. Pedretti (http://forge.taotesting.com/issues/3466)

It makes the split effective and prevents a noticeable display slowdown on the results section in case of a whole bunch of results stored.

![43ad7e2c-8881-11e5-96c0-927611a57322](https://cloud.githubusercontent.com/assets/8090142/11397931/73f41c56-937d-11e5-8165-183e35907890.png)
![43c4b0c4-8881-11e5-9970-e31c64686a8e](https://cloud.githubusercontent.com/assets/8090142/11397932/777342d0-937d-11e5-90fd-e74f0abe0a0e.png)

