### PR TITLE
Fix/tao 4145 missing indexes

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label' => 'extension-tao-outcomerds',
     'description' => 'extension that allows a storage in relational database',
     'license' => 'GPL-2.0',
-    'version' => '1.1.4',
+    'version' => '1.1.5',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoResultServer' => '>=2.6'

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -50,6 +50,10 @@ class RdsResultStorage extends \tao_models_classes_GenerisService
     const ITEM_COLUMN = "item";
     const VARIABLE_VALUE = "value";
     const VARIABLE_IDENTIFIER = "identifier";
+
+    const CALL_ID_ITEM_INDEX = "idx_variables_storage_call_id_item";
+    const CALL_ID_TEST_INDEX = "idx_variables_storage_call_id_test";
+
     /** @deprecated */
     const VARIABLE_CLASS = "class";
     const VARIABLES_FK_COLUMN = "results_result_id";

--- a/scripts/install/AddIndexes.php
+++ b/scripts/install/AddIndexes.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoOutcomeRds\scripts\install;
+
+use oat\oatbox\extension\AbstractAction;
+use oat\taoOutcomeRds\model\RdsResultStorage;
+
+class AddIndexes extends AbstractAction
+{
+    /**
+     *
+     * @param $params
+     * @return \common_report_Report
+     */
+    public function __invoke($params)
+    {
+        $persistence = \common_persistence_Manager::getPersistence('default');
+
+        $schema = $persistence->getDriver()->getSchemaManager()->createSchema();
+        $fromSchema = clone $schema;
+
+
+        if($schema->hasTable(RdsResultStorage::VARIABLES_TABLENAME)){
+            try{
+            $tableVariables = $schema->getTable(RdsResultStorage::VARIABLES_TABLENAME);
+            $i = 0;
+            if(!$tableVariables->hasIndex(RdsResultStorage::CALL_ID_ITEM_INDEX)){
+                $tableVariables->addIndex(array(RdsResultStorage::CALL_ID_ITEM_COLUMN), RdsResultStorage::CALL_ID_ITEM_INDEX);
+                $i++;
+            }
+
+            if(!$tableVariables->hasIndex(RdsResultStorage::CALL_ID_TEST_INDEX)){
+                $tableVariables->addIndex(array(RdsResultStorage::CALL_ID_TEST_COLUMN), RdsResultStorage::CALL_ID_TEST_INDEX);
+                $i++;
+            }
+
+            $queries = $persistence->getPlatform()->getMigrateSchemaSql($fromSchema, $schema);
+
+
+            foreach ($queries as $query) {
+                $persistence->exec($query);
+            }
+
+            } catch(\PDOException $e){
+                \common_Logger::w($e->getMessage());
+                return \common_report_Report::createFailure(__('Something went wrong during indexes addition'));
+            }
+
+            if($i === 0){
+                return \common_report_Report::createInfo(__('No indexes to add'));
+            } else {
+                return \common_report_Report::createSuccess(__('Successfully added %s indexes', $i));
+            }
+        }
+
+        return \common_report_Report::createFailure(__('The table %s doesn\'t exist', RdsResultStorage::VARIABLES_TABLENAME));
+    }
+}

--- a/scripts/install/createTables.php
+++ b/scripts/install/createTables.php
@@ -38,6 +38,7 @@ try {
     $tableResults->addColumn(RdsResultStorage::TEST_TAKER_COLUMN, "string", array("notnull" => false, "length" => 255));
     $tableResults->addColumn(RdsResultStorage::DELIVERY_COLUMN, "string", array("notnull" => false, "length" => 255));
     $tableResults->setPrimaryKey(array(RdsResultStorage::RESULTS_TABLE_ID));
+    
 
     $tableVariables->addColumn(RdsResultStorage::VARIABLES_TABLE_ID, "integer", array("autoincrement" => true));
     $tableVariables->addColumn(RdsResultStorage::CALL_ID_TEST_COLUMN, "string", array("notnull" => false, "length" => 255));
@@ -55,6 +56,8 @@ try {
         array(),
         RdsResultStorage::VARIABLES_FK_NAME
     );
+    $tableVariables->addIndex(array(RdsResultsStorage::CALL_ID_ITEM_COLUMN), 'idx_variables_storage_call_id_item');
+    $tableVariables->addIndex(array(RdsResultsStorage::CALL_ID_TEST_COLUMN), 'idx_variables_storage_call_id_test');
 
 } catch(SchemaException $e) {
     common_Logger::i('Database Schema already up to date.');

--- a/scripts/install/createTables.php
+++ b/scripts/install/createTables.php
@@ -56,8 +56,8 @@ try {
         array(),
         RdsResultStorage::VARIABLES_FK_NAME
     );
-    $tableVariables->addIndex(array(RdsResultStorage::CALL_ID_ITEM_COLUMN), 'idx_variables_storage_call_id_item');
-    $tableVariables->addIndex(array(RdsResultStorage::CALL_ID_TEST_COLUMN), 'idx_variables_storage_call_id_test');
+    $tableVariables->addIndex(array(RdsResultStorage::CALL_ID_ITEM_COLUMN), RdsResultStorage::CALL_ID_ITEM_INDEX);
+    $tableVariables->addIndex(array(RdsResultStorage::CALL_ID_TEST_COLUMN), RdsResultStorage::CALL_ID_TEST_INDEX);
 
 } catch(SchemaException $e) {
     common_Logger::i('Database Schema already up to date.');

--- a/scripts/install/createTables.php
+++ b/scripts/install/createTables.php
@@ -56,8 +56,8 @@ try {
         array(),
         RdsResultStorage::VARIABLES_FK_NAME
     );
-    $tableVariables->addIndex(array(RdsResultsStorage::CALL_ID_ITEM_COLUMN), 'idx_variables_storage_call_id_item');
-    $tableVariables->addIndex(array(RdsResultsStorage::CALL_ID_TEST_COLUMN), 'idx_variables_storage_call_id_test');
+    $tableVariables->addIndex(array(RdsResultStorage::CALL_ID_ITEM_COLUMN), 'idx_variables_storage_call_id_item');
+    $tableVariables->addIndex(array(RdsResultStorage::CALL_ID_TEST_COLUMN), 'idx_variables_storage_call_id_test');
 
 } catch(SchemaException $e) {
     common_Logger::i('Database Schema already up to date.');

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -120,7 +120,7 @@ class Updater extends \common_ext_ExtensionUpdater
 		}
 		$this->setVersion($currentVersion);
 		
-		$this->skip('1.1.0','1.1.4');
+		$this->skip('1.1.0','1.1.5');
 
 	}
 }


### PR DESCRIPTION
As we had to use another set of indexes than the formerly provided one. However, @antoinerobin, if you feel than the following indexes

create index v_item on variables_storage(item);
create index r_ttaker on results_storage(test_taker);

**are necessary (we suppose it's about the results export in TAO Outcome UI), please add them before merging the pull request.**

All the best,