### PR TITLE
Test and refactor RdsResultStorage

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label' => 'extension-tao-outcomerds',
     'description' => 'extension that allows a storage in relational database',
     'license' => 'GPL-2.0',
-    'version' => '6.0.0',
+    'version' => '6.0.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoResultServer' => '>=6.5.0',

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -163,7 +163,7 @@ class RdsResultStorage extends ConfigurableService
             ->from(self::RESULTS_TABLENAME)
             ->andWhere(self::RESULTS_TABLE_ID .' = :id')
             ->setParameter('id', $deliveryResultIdentifier);
-        if ($qb->execute()->fetchColumn() == 0) {
+        if ((int) $qb->execute()->fetchColumn() === 0) {
             $this->getPersistence()->insert(
                 self::RESULTS_TABLENAME,
                 [

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -39,13 +39,11 @@ class RdsResultStorage extends ConfigurableService
 
     /**
      * Constants for the database creation and data access
-     *
      */
     const RESULTS_TABLENAME = "results_storage";
     const RESULTS_TABLE_ID = 'result_id';
     const TEST_TAKER_COLUMN = 'test_taker';
     const DELIVERY_COLUMN = 'delivery';
-
 
     const VARIABLES_TABLENAME = "variables_storage";
     const VARIABLES_TABLE_ID = "variable_id";
@@ -77,6 +75,11 @@ class RdsResultStorage extends ConfigurableService
 
     /** result storage persistence identifier */
     const OPTION_PERSISTENCE = 'persistence';
+
+    // Fields for results retrieval.
+    const FIELD_DELIVERY_RESULT = 'deliveryResultIdentifier';
+    const FIELD_TEST_TAKER = 'testTakerIdentifier';
+    const FIELD_DELIVERY = 'deliveryIdentifier';
 
     /**
      * @return \common_persistence_SqlPersistence
@@ -443,8 +446,8 @@ class RdsResultStorage extends ConfigurableService
         $results = $this->getPersistence()->query($sql);
         foreach ($results as $value) {
             $returnValue[] = array(
-                "deliveryResultIdentifier" => $value[self::RESULTS_TABLE_ID],
-                "testTakerIdentifier" => $value[self::TEST_TAKER_COLUMN]
+                self::FIELD_DELIVERY_RESULT => $value[self::RESULTS_TABLE_ID],
+                self::FIELD_TEST_TAKER => $value[self::TEST_TAKER_COLUMN]
             );
         }
         return $returnValue;
@@ -461,8 +464,8 @@ class RdsResultStorage extends ConfigurableService
         $results = $this->getPersistence()->query($sql);
         foreach ($results as $value) {
             $returnValue[] = array(
-                "deliveryResultIdentifier" => $value[self::RESULTS_TABLE_ID],
-                "deliveryIdentifier" => $value[self::DELIVERY_COLUMN]
+                self::FIELD_DELIVERY_RESULT => $value[self::RESULTS_TABLE_ID],
+                self::FIELD_DELIVERY => $value[self::DELIVERY_COLUMN]
             );
         }
         return $returnValue;
@@ -473,6 +476,10 @@ class RdsResultStorage extends ConfigurableService
      */
     public function getResultByDelivery($delivery, $options = array())
     {
+        if (!is_array($delivery)) {
+            $delivery = [$delivery];
+        }
+
         $returnValue = array();
         $sql = 'SELECT * FROM ' . self::RESULTS_TABLENAME;
         $params = array();
@@ -500,9 +507,9 @@ class RdsResultStorage extends ConfigurableService
         $results = $this->getPersistence()->query($sql, $params);
         foreach ($results as $value) {
             $returnValue[] = array(
-                "deliveryResultIdentifier" => $value[self::RESULTS_TABLE_ID],
-                "testTakerIdentifier" => $value[self::TEST_TAKER_COLUMN],
-                "deliveryIdentifier" => $value[self::DELIVERY_COLUMN]
+                self::FIELD_DELIVERY_RESULT => $value[self::RESULTS_TABLE_ID],
+                self::FIELD_TEST_TAKER => $value[self::TEST_TAKER_COLUMN],
+                self::FIELD_DELIVERY => $value[self::DELIVERY_COLUMN]
             );
         }
         return $returnValue;
@@ -510,6 +517,10 @@ class RdsResultStorage extends ConfigurableService
     }
 
     public function countResultByDelivery($delivery){
+        if (!is_array($delivery)) {
+            $delivery = [$delivery];
+        }
+
         $sql = 'SELECT COUNT(*) FROM ' . self::RESULTS_TABLENAME;
         $params = array();
 

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -22,10 +22,9 @@ namespace oat\taoOutcomeRds\model;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
+use oat\oatbox\service\ConfigurableService;
 use oat\taoResultServer\models\classes\ResultDeliveryExecutionDelete;
 use oat\taoResultServer\models\classes\ResultManagement;
-use \core_kernel_classes_Resource;
-use oat\oatbox\service\ConfigurableService;
 
 /**
  * Implements tao results storage using the configured persistency "taoOutcomeRds"
@@ -35,6 +34,7 @@ class RdsResultStorage extends ConfigurableService
     implements \taoResultServer_models_classes_WritableResultStorage, \taoResultServer_models_classes_ReadableResultStorage, ResultManagement
 {
     use ResultDeliveryExecutionDelete;
+
     const SERVICE_ID = 'taoOutcomeRds/RdsResultStorage';
 
     /**

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -101,13 +101,10 @@ class RdsResultStorage extends ConfigurableService
     /**
      * Store the test variable in table and its value in key/value storage
      *
-     * @param type $deliveryResultIdentifier
-     *            lis_result_sourcedid
-     * @param type $test
-     *            ignored
+     * @param string $deliveryResultIdentifier
+     * @param string $test
      * @param \taoResultServer_models_classes_Variable $testVariable
-     * @param type $callIdTest
-     *            ignored
+     * @param string $callIdTest
      */
     public function storeTestVariable(
         $deliveryResultIdentifier,

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -131,6 +131,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.2.0');
         }
 
-		$this->skip('2.2.0','6.0.0');
+		$this->skip('2.2.0','6.0.1');
 	}
 }

--- a/test/unit/model/RdsResultStorageTest.php
+++ b/test/unit/model/RdsResultStorageTest.php
@@ -244,9 +244,6 @@ class RdsResultStorageTest extends TestCase
         $this->assertEquals(1, $this->instance->countResultByDelivery([]));
     }
 
-    ////////////////////////////////////////////////////////////////////////////
-    /// Variables storing
-
     public function testStoreItemVariable()
     {
         $deliveryResultIdentifier = "MyDeliveryResultIdentifier#1";

--- a/test/unit/model/RdsResultStorageTest.php
+++ b/test/unit/model/RdsResultStorageTest.php
@@ -135,12 +135,12 @@ class RdsResultStorageTest extends TestCase
     /**
      * @dataProvider resultByDeliveryToTest
      *
-     * @param $ids
-     * @param $selected
-     * @param $options
-     * @param $expected
+     * @param array $ids
+     * @param array|string $selected
+     * @param array $options
+     * @param array $expected
      */
-    public function testGetResultByDelivery($ids, $selected, $options, $expected)
+    public function testGetResultByDelivery(array $ids, $selected, array $options, array $expected)
     {
         $this->instance->storeRelatedTestTaker($ids['dr11'], $ids['tt1']);
         $this->instance->storeRelatedDelivery($ids['dr11'], $ids['d1']);

--- a/test/unit/model/RdsResultStorageTest.php
+++ b/test/unit/model/RdsResultStorageTest.php
@@ -30,7 +30,7 @@ use Prophecy\Argument;
 /**
  * Test Rds result storage
  *
- * @author Antoine Robin, <antoine.robin@vesperiagroup.com>
+ * @author  Antoine Robin, <antoine.robin@vesperiagroup.com>
  * @package taoOutcomeRds
  *
  */
@@ -128,7 +128,7 @@ class RdsResultStorageTest extends TestCase
         $this->instance->storeRelatedDelivery($deliveryResultIdentifier2, $deliveryIdentifier2);
 
         $this->assertEquals(2, $this->instance->countResultByDelivery([]));
-        $this->assertEquals(1, $this->instance->countResultByDelivery([$deliveryIdentifier1]));
+        $this->assertEquals(1, $this->instance->countResultByDelivery($deliveryIdentifier1));
     }
 
     /**
@@ -152,9 +152,9 @@ class RdsResultStorageTest extends TestCase
 
         foreach ($expected as &$fields) {
             $fields = [
-                'deliveryResultIdentifier' => $ids[$fields[0]],
-                'testTakerIdentifier' => $ids[$fields[1]],
-                'deliveryIdentifier' => $ids[$fields[2]],
+                RdsResultStorage::FIELD_DELIVERY_RESULT => $ids[$fields[0]],
+                RdsResultStorage::FIELD_TEST_TAKER => $ids[$fields[1]],
+                RdsResultStorage::FIELD_DELIVERY => $ids[$fields[2]],
             ];
         }
 
@@ -217,7 +217,7 @@ class RdsResultStorageTest extends TestCase
             ],
             'not existing delivery' => [
                 $ids,
-                ['not existing delivery'],
+                'not existing delivery',
                 [],
                 [],
             ],

--- a/test/unit/model/RdsResultStorageTest.php
+++ b/test/unit/model/RdsResultStorageTest.php
@@ -26,6 +26,7 @@ use oat\generis\test\TestCase;
 use oat\taoOutcomeRds\model\RdsResultStorage;
 use oat\taoOutcomeRds\scripts\install\createTables;
 use Prophecy\Argument;
+use taoResultServer_models_classes_OutcomeVariable as OutcomeVariable;
 
 /**
  * Test Rds result storage
@@ -249,61 +250,240 @@ class RdsResultStorageTest extends TestCase
     public function testStoreItemVariable()
     {
         $deliveryResultIdentifier = "MyDeliveryResultIdentifier#1";
-        $test = "MyGreatTest#2";
-        $item = "MyGreatItem#2";
-        $callId = "MyCallId#2";
+        $test = "MyGreatTest#1";
+        $item = "MyGreatItem#1";
+        $callId = "MyCallId#1";
+        $baseType = 'float';
+        $cardinality = 'multiple';
+        $identifier = 'ItemIdentifier';
+        $value = 'MyValue';
 
-        $itemVariable = new \taoResultServer_models_classes_OutcomeVariable();
-        $itemVariable->setBaseType('float');
-        $itemVariable->setCardinality('multiple');
-        $itemVariable->setIdentifier('Identifier');
-        $itemVariable->setValue('MyValue');
+        $itemVariable = new OutcomeVariable();
+        $itemVariable->setBaseType($baseType);
+        $itemVariable->setCardinality($cardinality);
+        $itemVariable->setIdentifier($identifier);
+        $itemVariable->setValue($value);
 
         $this->instance->storeItemVariable($deliveryResultIdentifier, $test, $item, $itemVariable, $callId);
-        $tmp = $this->instance->getVariable($callId, 'Identifier');
+        $variables = $this->instance->getVariable($callId, $identifier);
 
-        $object = array_shift($tmp);
+        $object = array_shift($variables);
         $this->assertEquals($test, $object->test);
         $this->assertEquals($item, $object->item);
-        $this->assertEquals('float', $object->variable->getBaseType());
-        $this->assertEquals('multiple', $object->variable->getCardinality());
-        $this->assertEquals('Identifier', $object->variable->getIdentifier());
-        $this->assertEquals('MyValue', $object->variable->getValue());
-        $this->assertInstanceOf('taoResultServer_models_classes_OutcomeVariable', $object->variable);
+        $this->assertInstanceOf(OutcomeVariable::class, $object->variable);
+        $this->assertEquals($baseType, $object->variable->getBaseType());
+        $this->assertEquals($cardinality, $object->variable->getCardinality());
+        $this->assertEquals($identifier, $object->variable->getIdentifier());
+        $this->assertEquals($value, $object->variable->getValue());
 
-        $this->assertEquals('float', $this->instance->getVariableProperty($object->uri, 'baseType'));
-        $this->assertEquals('multiple', $this->instance->getVariableProperty($object->uri, 'cardinality'));
-        $this->assertEquals('Identifier', $this->instance->getVariableProperty($object->uri, 'identifier'));
-        $this->assertEquals('MyValue', $this->instance->getVariableProperty($object->uri, 'value'));
+        $this->assertEquals($baseType, $this->instance->getVariableProperty($object->uri, 'baseType'));
+        $this->assertEquals($cardinality, $this->instance->getVariableProperty($object->uri, 'cardinality'));
+        $this->assertEquals($identifier, $this->instance->getVariableProperty($object->uri, 'identifier'));
+        $this->assertEquals($value, $this->instance->getVariableProperty($object->uri, 'value'));
         $this->assertNull($this->instance->getVariableProperty($object->uri, 'unknownProperty'));
+    }
+
+    public function testStoreItemVariables()
+    {
+        $deliveryResultIdentifier = "MyDeliveryResultIdentifier#1";
+        $test = "MyGreatTest#1";
+        $item = "MyGreatItem#1";
+        $callId = "MyCallId#1";
+        $baseType1 = 'float';
+        $cardinality1 = 'multiple';
+        $identifier1 = 'ItemIdentifier1';
+        $value1 = 'MyValue1';
+        $baseType2 = 'string';
+        $cardinality2 = 'ordered';
+        $identifier2 = 'ItemIdentifier2';
+        $value2 = 'MyValue2';
+
+        $itemVariable1 = new OutcomeVariable();
+        $itemVariable1->setBaseType($baseType1);
+        $itemVariable1->setCardinality($cardinality1);
+        $itemVariable1->setIdentifier($identifier1);
+        $itemVariable1->setValue($value1);
+
+        $itemVariable2 = new OutcomeVariable();
+        $itemVariable2->setBaseType($baseType2);
+        $itemVariable2->setCardinality($cardinality2);
+        $itemVariable2->setIdentifier($identifier2);
+        $itemVariable2->setValue($value2);
+
+        $this->instance->storeItemVariables($deliveryResultIdentifier, $test, $item, [$itemVariable1, $itemVariable2], $callId);
+        $variables = $this->instance->getVariables($callId);
+
+        $object = array_shift($variables)[0];
+        $this->assertEquals($test, $object->test);
+        $this->assertEquals($item, $object->item);
+        $this->assertInstanceOf(OutcomeVariable::class, $object->variable);
+        $this->assertEquals($baseType1, $object->variable->getBaseType());
+        $this->assertEquals($cardinality1, $object->variable->getCardinality());
+        $this->assertEquals($identifier1, $object->variable->getIdentifier());
+        $this->assertEquals($value1, $object->variable->getValue());
+
+        $object = array_shift($variables)[0];
+        $this->assertEquals($test, $object->test);
+        $this->assertEquals($item, $object->item);
+        $this->assertInstanceOf(OutcomeVariable::class, $object->variable);
+        $this->assertEquals($baseType2, $object->variable->getBaseType());
+        $this->assertEquals($cardinality2, $object->variable->getCardinality());
+        $this->assertEquals($identifier2, $object->variable->getIdentifier());
+        $this->assertEquals($value2, $object->variable->getValue());
     }
 
     public function testStoreTestVariable()
     {
         $deliveryResultIdentifier = "MyDeliveryResultIdentifier#1";
-        $test = "MyGreatTest#3";
-        $callId = "MyCallId#3";
+        $test = "MyGreatTest#1";
+        $callId = "MyCallId#1";
+        $baseType = 'float';
+        $cardinality = 'multiple';
+        $identifier = 'TestIdentifier';
+        $value = 'MyValue';
 
-        $testVariable = new \taoResultServer_models_classes_OutcomeVariable();
-        $testVariable->setBaseType('float');
-        $testVariable->setCardinality('multiple');
-        $testVariable->setIdentifier('TestIdentifier');
-        $testVariable->setValue('MyValue');
+        $testVariable = new OutcomeVariable();
+        $testVariable->setBaseType($baseType);
+        $testVariable->setCardinality($cardinality);
+        $testVariable->setIdentifier($identifier);
+        $testVariable->setValue($value);
 
         $this->instance->storeTestVariable($deliveryResultIdentifier, $test, $testVariable, $callId);
-        $tmp = $this->instance->getVariable($callId, 'TestIdentifier');
-        $object = array_shift($tmp);
+        $variables = $this->instance->getVariable($callId, $identifier);
+
+        $object = array_shift($variables);
         $this->assertEquals($test, $object->test);
         $this->assertNull($object->item);
-        $this->assertEquals('float', $object->variable->getBaseType());
-        $this->assertEquals('multiple', $object->variable->getCardinality());
-        $this->assertEquals('TestIdentifier', $object->variable->getIdentifier());
-        $this->assertEquals('MyValue', $object->variable->getValue());
-        $this->assertInstanceOf('taoResultServer_models_classes_OutcomeVariable', $object->variable);
+        $this->assertInstanceOf(OutcomeVariable::class, $object->variable);
+        $this->assertEquals($baseType, $object->variable->getBaseType());
+        $this->assertEquals($cardinality, $object->variable->getCardinality());
+        $this->assertEquals($identifier, $object->variable->getIdentifier());
+        $this->assertEquals($value, $object->variable->getValue());
 
-        $this->assertEquals('float', $this->instance->getVariableProperty($object->uri, 'baseType'));
-        $this->assertEquals('multiple', $this->instance->getVariableProperty($object->uri, 'cardinality'));
-        $this->assertEquals('TestIdentifier', $this->instance->getVariableProperty($object->uri, 'identifier'));
-        $this->assertEquals('MyValue', $this->instance->getVariableProperty($object->uri, 'value'));
+        $this->assertEquals($baseType, $this->instance->getVariableProperty($object->uri, 'baseType'));
+        $this->assertEquals($cardinality, $this->instance->getVariableProperty($object->uri, 'cardinality'));
+        $this->assertEquals($identifier, $this->instance->getVariableProperty($object->uri, 'identifier'));
+        $this->assertEquals($value, $this->instance->getVariableProperty($object->uri, 'value'));
+    }
+
+    public function testStoreTestVariables()
+    {
+        $deliveryResultIdentifier = "MyDeliveryResultIdentifier#1";
+        $test = "MyGreatTest#1";
+        $callId = "MyCallId#1";
+        $baseType1 = 'float';
+        $cardinality1 = 'multiple';
+        $identifier1 = 'ItemIdentifier1';
+        $value1 = 'MyValue1';
+        $baseType2 = 'string';
+        $cardinality2 = 'ordered';
+        $identifier2 = 'ItemIdentifier2';
+        $value2 = 'MyValue2';
+
+        $itemVariable1 = new OutcomeVariable();
+        $itemVariable1->setBaseType($baseType1);
+        $itemVariable1->setCardinality($cardinality1);
+        $itemVariable1->setIdentifier($identifier1);
+        $itemVariable1->setValue($value1);
+
+        $itemVariable2 = new OutcomeVariable();
+        $itemVariable2->setBaseType($baseType2);
+        $itemVariable2->setCardinality($cardinality2);
+        $itemVariable2->setIdentifier($identifier2);
+        $itemVariable2->setValue($value2);
+
+        $this->instance->storeTestVariables($deliveryResultIdentifier, $test, [$itemVariable1, $itemVariable2], $callId);
+        $variables = $this->instance->getDeliveryVariables($deliveryResultIdentifier);
+
+        $object = array_shift($variables)[0];
+        $this->assertEquals($test, $object->test);
+        $this->assertInstanceOf(OutcomeVariable::class, $object->variable);
+        $this->assertEquals($baseType1, $object->variable->getBaseType());
+        $this->assertEquals($cardinality1, $object->variable->getCardinality());
+        $this->assertEquals($identifier1, $object->variable->getIdentifier());
+        $this->assertEquals($value1, $object->variable->getValue());
+
+        $object = array_shift($variables)[0];
+        $this->assertEquals($test, $object->test);
+        $this->assertInstanceOf(OutcomeVariable::class, $object->variable);
+        $this->assertEquals($baseType2, $object->variable->getBaseType());
+        $this->assertEquals($cardinality2, $object->variable->getCardinality());
+        $this->assertEquals($identifier2, $object->variable->getIdentifier());
+        $this->assertEquals($value2, $object->variable->getValue());
+    }
+
+    public function testGetAllCallIds()
+    {
+        $deliveryResultIdentifier = "MyDeliveryResultIdentifier#1";
+        $test = "MyGreatTest#1";
+        $item = "MyGreatItem#1";
+        $testCallId = "testCallId#1";
+        $itemCallId = "itemCallId#1";
+
+        $baseType = 'float';
+        $cardinality = 'multiple';
+        $identifier = 'ItemIdentifier1';
+        $value = 'MyValue1';
+
+        $itemVariable = new OutcomeVariable();
+        $itemVariable->setBaseType($baseType);
+        $itemVariable->setCardinality($cardinality);
+        $itemVariable->setIdentifier($identifier);
+        $itemVariable->setValue($value);
+
+        $this->instance->storeItemVariable($deliveryResultIdentifier, $test, $item, $itemVariable, $itemCallId);
+        $this->instance->storeTestVariable($deliveryResultIdentifier, $test, $itemVariable, $testCallId);
+
+        $this->assertSame([$testCallId, $itemCallId], $this->instance->getAllCallIds());
+    }
+
+    public function testGetRelatedItemCallIds()
+    {
+        $deliveryResultIdentifier = "MyDeliveryResultIdentifier#1";
+        $test = "MyGreatTest#1";
+        $item = "MyGreatItem#1";
+        $testCallId = "testCallId#1";
+        $itemCallId = "itemCallId#1";
+
+        $baseType = 'float';
+        $cardinality = 'multiple';
+        $identifier = 'ItemIdentifier1';
+        $value = 'MyValue1';
+
+        $itemVariable = new OutcomeVariable();
+        $itemVariable->setBaseType($baseType);
+        $itemVariable->setCardinality($cardinality);
+        $itemVariable->setIdentifier($identifier);
+        $itemVariable->setValue($value);
+
+        $this->instance->storeItemVariable($deliveryResultIdentifier, $test, $item, $itemVariable, $itemCallId);
+        $this->instance->storeTestVariable($deliveryResultIdentifier, $test, $itemVariable, $testCallId);
+
+        $this->assertSame([$itemCallId], $this->instance->getRelatedItemCallIds($deliveryResultIdentifier));
+    }
+
+    public function testGetRelatedTestCallIds()
+    {
+        $deliveryResultIdentifier = "MyDeliveryResultIdentifier#1";
+        $test = "MyGreatTest#1";
+        $item = "MyGreatItem#1";
+        $testCallId = "testCallId#1";
+        $itemCallId = "itemCallId#1";
+
+        $baseType = 'float';
+        $cardinality = 'multiple';
+        $identifier = 'ItemIdentifier1';
+        $value = 'MyValue1';
+
+        $itemVariable = new OutcomeVariable();
+        $itemVariable->setBaseType($baseType);
+        $itemVariable->setCardinality($cardinality);
+        $itemVariable->setIdentifier($identifier);
+        $itemVariable->setValue($value);
+
+        $this->instance->storeItemVariable($deliveryResultIdentifier, $test, $item, $itemVariable, $itemCallId);
+        $this->instance->storeTestVariable($deliveryResultIdentifier, $test, $itemVariable, $testCallId);
+
+        $this->assertSame([$testCallId], $this->instance->getRelatedTestCallIds($deliveryResultIdentifier));
     }
 }

--- a/test/unit/model/RdsResultStorageTest.php
+++ b/test/unit/model/RdsResultStorageTest.php
@@ -81,6 +81,171 @@ class RdsResultStorageTest extends TestCase
         $this->assertSame($deliveryIdentifier, $this->instance->getDelivery($deliveryResultIdentifier));
     }
 
+    public function testGetAllTestTakerIds()
+    {
+        $deliveryResultIdentifier = "MyDeliveryResultIdentifier#1";
+        $testTakerIdentifier = "mytestTaker#1";
+        $this->instance->storeRelatedTestTaker($deliveryResultIdentifier, $testTakerIdentifier);
+
+        $expected = [
+            [
+                'deliveryResultIdentifier' => $deliveryResultIdentifier,
+                'testTakerIdentifier' => $testTakerIdentifier,
+            ],
+        ];
+
+        $this->assertSame($expected, $this->instance->getAllTestTakerIds());
+    }
+
+    public function testGetAllDeliveryIds()
+    {
+        $deliveryResultIdentifier = "MyDeliveryResultIdentifier#1";
+        $deliveryIdentifier = "mytestTaker#1";
+        $this->instance->storeRelatedDelivery($deliveryResultIdentifier, $deliveryIdentifier);
+
+        $expected = [
+            [
+                'deliveryResultIdentifier' => $deliveryResultIdentifier,
+                'deliveryIdentifier' => $deliveryIdentifier,
+            ],
+        ];
+
+        $this->assertSame($expected, $this->instance->getAllDeliveryIds());
+    }
+
+    public function testCountResultByDelivery()
+    {
+        $deliveryResultIdentifier1 = "MyDeliveryResultIdentifier#1";
+        $deliveryResultIdentifier2 = "MyDeliveryResultIdentifier#2";
+        $testTakerIdentifier1 = "mytestTaker#1";
+        $testTakerIdentifier2 = "mytestTaker#2";
+        $deliveryIdentifier1 = "myDelivery#1";
+        $deliveryIdentifier2 = "myDelivery#2";
+
+        $this->instance->storeRelatedTestTaker($deliveryResultIdentifier1, $testTakerIdentifier1);
+        $this->instance->storeRelatedDelivery($deliveryResultIdentifier1, $deliveryIdentifier1);
+        $this->instance->storeRelatedTestTaker($deliveryResultIdentifier2, $testTakerIdentifier2);
+        $this->instance->storeRelatedDelivery($deliveryResultIdentifier2, $deliveryIdentifier2);
+
+        $this->assertEquals(2, $this->instance->countResultByDelivery([]));
+        $this->assertEquals(1, $this->instance->countResultByDelivery([$deliveryIdentifier1]));
+    }
+
+    /**
+     * @dataProvider resultByDeliveryToTest
+     *
+     * @param $ids
+     * @param $selected
+     * @param $options
+     * @param $expected
+     */
+    public function testGetResultByDelivery($ids, $selected, $options, $expected)
+    {
+        $this->instance->storeRelatedTestTaker($ids['dr11'], $ids['tt1']);
+        $this->instance->storeRelatedDelivery($ids['dr11'], $ids['d1']);
+        $this->instance->storeRelatedTestTaker($ids['dr12'], $ids['tt2']);
+        $this->instance->storeRelatedDelivery($ids['dr12'], $ids['d1']);
+        $this->instance->storeRelatedTestTaker($ids['dr21'], $ids['tt1']);
+        $this->instance->storeRelatedDelivery($ids['dr21'], $ids['d2']);
+        $this->instance->storeRelatedTestTaker($ids['dr22'], $ids['tt2']);
+        $this->instance->storeRelatedDelivery($ids['dr22'], $ids['d2']);
+
+        foreach ($expected as &$fields) {
+            $fields = [
+                'deliveryResultIdentifier' => $ids[$fields[0]],
+                'testTakerIdentifier' => $ids[$fields[1]],
+                'deliveryIdentifier' => $ids[$fields[2]],
+            ];
+        }
+
+        $this->assertEquals($expected, $this->instance->getResultByDelivery($selected, $options));
+    }
+
+    public function resultByDeliveryToTest()
+    {
+        $ids = [
+            'dr11' => 'MyDeliveryResultIdentifier#11',
+            'dr12' => 'MyDeliveryResultIdentifier#12',
+            'dr21' => 'MyDeliveryResultIdentifier#21',
+            'dr22' => 'MyDeliveryResultIdentifier#22',
+            'tt1' => 'mytestTaker#1',
+            'tt2' => 'mytestTaker#2',
+            'd1' => 'myDelivery#1',
+            'd2' => 'myDelivery#2',
+        ];
+
+        return [
+            'all deliveries' => [
+                $ids,
+                [],
+                [],
+                [
+                    ['dr11', 'tt1', 'd1'],
+                    ['dr12', 'tt2', 'd1'],
+                    ['dr21', 'tt1', 'd2'],
+                    ['dr22', 'tt2', 'd2'],
+                ],
+            ],
+            'delivery1' => [
+                $ids,
+                [$ids['d1']],
+                ['order' => RdsResultStorage::DELIVERY_COLUMN],
+                [
+                    ['dr11', 'tt1', 'd1'],
+                    ['dr12', 'tt2', 'd1'],
+                ],
+            ],
+            'delivery1+2 by testtaker desc' => [
+                $ids,
+                [$ids['d1'], $ids['d2']],
+                ['order' => RdsResultStorage::TEST_TAKER_COLUMN, 'orderdir' => 'desc'],
+                [
+                    ['dr12', 'tt2', 'd1'],
+                    ['dr22', 'tt2', 'd2'],
+                    ['dr11', 'tt1', 'd1'],
+                    ['dr21', 'tt1', 'd2'],
+                ],
+            ],
+            'limit + offset' => [
+                $ids,
+                [],
+                ['order' => RdsResultStorage::RESULTS_TABLE_ID, 'limit' => 2, 'offset' => 1],
+                [
+                    ['dr12', 'tt2', 'd1'],
+                    ['dr21', 'tt1', 'd2'],
+                ],
+            ],
+            'not existing delivery' => [
+                $ids,
+                ['not existing delivery'],
+                [],
+                [],
+            ],
+        ];
+    }
+
+    public function testDeleteResult()
+    {
+        $deliveryResultIdentifier1 = "MyDeliveryResultIdentifier#1";
+        $deliveryResultIdentifier2 = "MyDeliveryResultIdentifier#2";
+        $testTakerIdentifier1 = "mytestTaker#1";
+        $testTakerIdentifier2 = "mytestTaker#2";
+        $deliveryIdentifier1 = "myDelivery#1";
+        $deliveryIdentifier2 = "myDelivery#2";
+
+        $this->instance->storeRelatedTestTaker($deliveryResultIdentifier1, $testTakerIdentifier1);
+        $this->instance->storeRelatedDelivery($deliveryResultIdentifier1, $deliveryIdentifier1);
+        $this->instance->storeRelatedTestTaker($deliveryResultIdentifier2, $testTakerIdentifier2);
+        $this->instance->storeRelatedDelivery($deliveryResultIdentifier2, $deliveryIdentifier2);
+
+        $this->assertEquals(2, $this->instance->countResultByDelivery([]));
+        $this->assertTrue($this->instance->deleteResult($deliveryResultIdentifier1));
+        $this->assertEquals(1, $this->instance->countResultByDelivery([]));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// Variables storing
+
     public function testStoreItemVariable()
     {
         $deliveryResultIdentifier = "MyDeliveryResultIdentifier#1";

--- a/test/unit/model/RdsResultStorageTest.php
+++ b/test/unit/model/RdsResultStorageTest.php
@@ -18,13 +18,14 @@
  *
  *
  */
+
 namespace oat\taoOutcomeRds\test\unit\model;
 
+use common_persistence_Manager;
 use oat\generis\test\TestCase;
 use oat\taoOutcomeRds\model\RdsResultStorage;
-use Prophecy\Argument;
 use oat\taoOutcomeRds\scripts\install\createTables;
-use common_persistence_Manager;
+use Prophecy\Argument;
 
 /**
  * Test Rds result storage
@@ -35,8 +36,6 @@ use common_persistence_Manager;
  */
 class RdsResultStorageTest extends TestCase
 {
-
-
     /**
      * @var RdsResultStorage
      */
@@ -63,7 +62,6 @@ class RdsResultStorageTest extends TestCase
     {
         $this->instance = null;
     }
-
 
     public function testStoreRelatedTestTaker()
     {
@@ -93,10 +91,8 @@ class RdsResultStorageTest extends TestCase
         $itemVariable = new \taoResultServer_models_classes_OutcomeVariable();
         $itemVariable->setBaseType('float');
         $itemVariable->setCardinality('multiple');
-        $itemVariable->setEpoch(microtime());
         $itemVariable->setIdentifier('Identifier');
         $itemVariable->setValue('MyValue');
-
 
         $this->instance->storeItemVariable($deliveryResultIdentifier, $test, $item, $itemVariable, $callId);
         $tmp = $this->instance->getVariable($callId, 'Identifier');
@@ -115,7 +111,6 @@ class RdsResultStorageTest extends TestCase
         $this->assertEquals('Identifier', $this->instance->getVariableProperty($object->uri, 'identifier'));
         $this->assertEquals('MyValue', $this->instance->getVariableProperty($object->uri, 'value'));
         $this->assertNull($this->instance->getVariableProperty($object->uri, 'unknownProperty'));
-
     }
 
     public function testStoreTestVariable()
@@ -127,10 +122,8 @@ class RdsResultStorageTest extends TestCase
         $testVariable = new \taoResultServer_models_classes_OutcomeVariable();
         $testVariable->setBaseType('float');
         $testVariable->setCardinality('multiple');
-        $testVariable->setEpoch(microtime());
         $testVariable->setIdentifier('TestIdentifier');
         $testVariable->setValue('MyValue');
-
 
         $this->instance->storeTestVariable($deliveryResultIdentifier, $test, $testVariable, $callId);
         $tmp = $this->instance->getVariable($callId, 'TestIdentifier');
@@ -147,8 +140,5 @@ class RdsResultStorageTest extends TestCase
         $this->assertEquals('multiple', $this->instance->getVariableProperty($object->uri, 'cardinality'));
         $this->assertEquals('TestIdentifier', $this->instance->getVariableProperty($object->uri, 'identifier'));
         $this->assertEquals('MyValue', $this->instance->getVariableProperty($object->uri, 'value'));
-
-
     }
-
 }


### PR DESCRIPTION
To ease the schema change summoned by the SPanner benchmark, a refactoring of this file should be made to have the fewest change in the future.
All the methods to be refactored has been covered with unit testing prior to refactor.
Refactoring was done with factorizing code and using querybuilder as much as possible.

Better follow the different commits to see the successive changes.
The version bump is minimal since it's only testing and refactoring.