### PR TITLE
Changed autoincrement primary key to uuid + added create_at to replace primary for order clauses.

### DIFF
--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -22,6 +22,7 @@ namespace oat\taoOutcomeRds\model;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
+use oat\generis\Helper\UuidPrimaryKeyTrait;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoResultServer\models\classes\ResultDeliveryExecutionDelete;
 use oat\taoResultServer\models\classes\ResultManagement;
@@ -33,6 +34,7 @@ use taoResultServer_models_classes_Variable as Variable;
 class RdsResultStorage extends ConfigurableService
     implements \taoResultServer_models_classes_WritableResultStorage, \taoResultServer_models_classes_ReadableResultStorage, ResultManagement
 {
+    use UuidPrimaryKeyTrait;
     use ResultDeliveryExecutionDelete;
 
     const SERVICE_ID = 'taoOutcomeRds/RdsResultStorage';
@@ -53,6 +55,7 @@ class RdsResultStorage extends ConfigurableService
     const ITEM_COLUMN = "item";
     const VARIABLE_VALUE = "value";
     const VARIABLE_IDENTIFIER = "identifier";
+    const CREATED_AT = "created_at";
 
     const CALL_ID_ITEM_INDEX = "idx_variables_storage_call_id_item";
     const CALL_ID_TEST_INDEX = "idx_variables_storage_call_id_test";
@@ -188,7 +191,7 @@ class RdsResultStorage extends ConfigurableService
             ->select('*')
             ->from(self::VARIABLES_TABLENAME)
             ->andWhere(self::CALL_ID_ITEM_COLUMN .' IN (:ids) OR ' . self::CALL_ID_TEST_COLUMN .' IN (:ids)')
-            ->orderBy(self::VARIABLES_TABLE_ID)
+            ->orderBy(self::CREATED_AT)
             ->setParameter('ids', $callId, Connection::PARAM_STR_ARRAY);
 
         $returnValue = [];
@@ -209,7 +212,7 @@ class RdsResultStorage extends ConfigurableService
             ->select('*')
             ->from(self::VARIABLES_TABLENAME)
             ->andWhere(self::VARIABLES_FK_COLUMN .' IN (:ids)')
-            ->orderBy(self::VARIABLES_TABLE_ID)
+            ->orderBy(self::CREATED_AT)
             ->setParameter('ids', $deliveryResultIdentifier, Connection::PARAM_STR_ARRAY);
 
         $returnValue = [];
@@ -517,10 +520,12 @@ class RdsResultStorage extends ConfigurableService
         }
 
         return [
+            self::VARIABLES_TABLE_ID => $this->getUniquePrimaryKey(),
             self::VARIABLES_FK_COLUMN => $deliveryResultIdentifier,
             self::TEST_COLUMN => $test,
             self::VARIABLE_IDENTIFIER => $variable->getIdentifier(),
             self::VARIABLE_VALUE => $this->serializeVariableValue($variable),
+            self::CREATED_AT => $this->getPersistence()->getPlatform()->getNowExpression(),
         ];
     }
 

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -22,7 +22,6 @@ namespace oat\taoOutcomeRds\model;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use oat\generis\Helper\UuidPrimaryKeyTrait;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoResultServer\models\classes\ResultDeliveryExecutionDelete;
 use oat\taoResultServer\models\classes\ResultManagement;
@@ -34,7 +33,6 @@ use taoResultServer_models_classes_Variable as Variable;
 class RdsResultStorage extends ConfigurableService
     implements \taoResultServer_models_classes_WritableResultStorage, \taoResultServer_models_classes_ReadableResultStorage, ResultManagement
 {
-    use UuidPrimaryKeyTrait;
     use ResultDeliveryExecutionDelete;
 
     const SERVICE_ID = 'taoOutcomeRds/RdsResultStorage';
@@ -520,7 +518,7 @@ class RdsResultStorage extends ConfigurableService
         }
 
         return [
-            self::VARIABLES_TABLE_ID => $this->getUniquePrimaryKey(),
+            self::VARIABLES_TABLE_ID => $this->getPersistence()->getUniquePrimaryKey(),
             self::VARIABLES_FK_COLUMN => $deliveryResultIdentifier,
             self::TEST_COLUMN => $test,
             self::VARIABLE_IDENTIFIER => $variable->getIdentifier(),

--- a/scripts/install/createTables.php
+++ b/scripts/install/createTables.php
@@ -58,7 +58,7 @@ class createTables extends AbstractAction
             $tableResults->setPrimaryKey(array(RdsResultStorage::RESULTS_TABLE_ID));
 
 
-            $tableVariables->addColumn(RdsResultStorage::VARIABLES_TABLE_ID, "integer", array("autoincrement" => true));
+            $tableVariables->addColumn(RdsResultStorage::VARIABLES_TABLE_ID, "string", array("length" => 23));
             $tableVariables->addColumn(RdsResultStorage::CALL_ID_TEST_COLUMN, "string", array("notnull" => false, "length" => 255));
             $tableVariables->addColumn(RdsResultStorage::CALL_ID_ITEM_COLUMN, "string", array("notnull" => false, "length" => 255));
             $tableVariables->addColumn(RdsResultStorage::TEST_COLUMN, "string", array("notnull" => false, "length" => 255));
@@ -66,6 +66,7 @@ class createTables extends AbstractAction
             $tableVariables->addColumn(RdsResultStorage::VARIABLE_VALUE, "text", array("notnull" => false));
             $tableVariables->addColumn(RdsResultStorage::VARIABLE_IDENTIFIER, "string", array("notnull" => false, "length" => 255));
             $tableVariables->addColumn(RdsResultStorage::VARIABLES_FK_COLUMN, "string", array("length" => 255));
+            $tableVariables->addColumn(RdsResultStorage::CREATED_AT, "datetime", array());
             $tableVariables->setPrimaryKey(array(RdsResultStorage::VARIABLES_TABLE_ID));
             $tableVariables->addForeignKeyConstraint(
                 $tableResults,


### PR DESCRIPTION
This PR requires https://github.com/oat-sa/extension-tao-outcomerds/pull/89.

This PR has not to be merged until the spanner benchmark is done.

The idea was to minimize the code change so the class was fully tested then refactored to have single points of changes to adapt to the schema changes here.
