### PR TITLE
add unique constraint to variables storage

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'version' => '6.1.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'taoResultServer' => '>=6.5.0',
+        'taoResultServer' => '>=9.3.0',
         'generis' => '>=11.0.0'
     ),
     // for compatibility

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label' => 'extension-tao-outcomerds',
     'description' => 'extension that allows a storage in relational database',
     'license' => 'GPL-2.0',
-    'version' => '6.0.2',
+    'version' => '6.1.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoResultServer' => '>=6.5.0',

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -108,7 +108,7 @@ class RdsResultStorage extends ConfigurableService
             );
         }
 
-        $this->insertMultiple(self::VARIABLES_TABLENAME, $dataToInsert);
+        $this->insertMultiple($dataToInsert);
     }
 
     /**
@@ -142,7 +142,7 @@ class RdsResultStorage extends ConfigurableService
             );
         }
 
-        $this->insertMultiple(self::VARIABLES_TABLENAME, $dataToInsert);
+        $this->insertMultiple($dataToInsert);
     }
 
     public function storeRelatedTestTaker($deliveryResultIdentifier, $testTakerIdentifier)
@@ -589,20 +589,19 @@ class RdsResultStorage extends ConfigurableService
     }
 
     /**
-     * @param string $tableName
      * @param array $data
      * @throws DuplicateVariableException
      */
-    private function insertMultiple(string $tableName, array $data)
+    private function insertMultiple(array $data)
     {
         $duplicatedData = false;
         try {
-            $this->getPersistence()->insertMultiple($tableName, $data);
+            $this->getPersistence()->insertMultiple(self::VARIABLES_TABLENAME, $data);
         } catch (UniqueConstraintViolationException $e) {
             $duplicatedData = true;
             foreach ($data as $row) {
                 try {
-                    $this->getPersistence()->insert($tableName, $row);
+                    $this->getPersistence()->insert(self::VARIABLES_TABLENAME, $row);
                 } catch (UniqueConstraintViolationException $e) {
                     //do nothing, just skip it
                 }

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -591,7 +591,7 @@ class RdsResultStorage extends ConfigurableService
     /**
      * @param string $tableName
      * @param array $data
-     * @throws UniqueConstraintViolationException
+     * @throws DuplicateVariableException
      */
     private function insertMultiple(string $tableName, array $data)
     {
@@ -604,7 +604,7 @@ class RdsResultStorage extends ConfigurableService
                 try {
                     $this->getPersistence()->insert($tableName, $row);
                 } catch (UniqueConstraintViolationException $e) {
-                    $g = 'sdf';
+                    //do nothing, just skip it
                 }
             }
         }

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -57,6 +57,7 @@ class RdsResultStorage extends ConfigurableService
     const ITEM_COLUMN = "item";
     const VARIABLE_VALUE = "value";
     const VARIABLE_IDENTIFIER = "identifier";
+    const VARIABLE_HASH = "variable_hash";
 
     const CALL_ID_ITEM_INDEX = "idx_variables_storage_call_id_item";
     const CALL_ID_TEST_INDEX = "idx_variables_storage_call_id_test";
@@ -484,6 +485,7 @@ class RdsResultStorage extends ConfigurableService
         $variableData = $this->prepareVariableData($deliveryResultIdentifier, $test, $variable);
         $variableData[self::ITEM_COLUMN] = $item;
         $variableData[self::CALL_ID_ITEM_COLUMN] = $callId;
+        $variableData[self::VARIABLE_HASH] = md5($deliveryResultIdentifier.$variableData[self::VARIABLE_VALUE].$callId);
 
         return $variableData;
     }
@@ -502,7 +504,7 @@ class RdsResultStorage extends ConfigurableService
     {
         $variableData = $this->prepareVariableData($deliveryResultIdentifier, $test, $variable);
         $variableData[self::CALL_ID_TEST_COLUMN] = $callId;
-
+        $variableData[self::VARIABLE_HASH] = md5($deliveryResultIdentifier.$variableData[self::VARIABLE_VALUE].$callId);
         return $variableData;
     }
 

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -26,7 +26,6 @@ use oat\oatbox\service\ConfigurableService;
 use oat\taoResultServer\models\classes\ResultDeliveryExecutionDelete;
 use oat\taoResultServer\models\classes\ResultManagement;
 use oat\taoResultServer\models\Exceptions\DuplicateVariableException;
-use Doctrine\DBAL\Exception\ConstraintViolationException;
 use taoResultServer_models_classes_Variable as Variable;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -484,7 +484,7 @@ class RdsResultStorage extends ConfigurableService
         $variableData = $this->prepareVariableData($deliveryResultIdentifier, $test, $variable);
         $variableData[self::ITEM_COLUMN] = $item;
         $variableData[self::CALL_ID_ITEM_COLUMN] = $callId;
-        $variableData[self::VARIABLE_HASH] = md5($deliveryResultIdentifier.$variableData[self::VARIABLE_VALUE].$callId);
+        $variableData[self::VARIABLE_HASH] = $deliveryResultIdentifier.md5($deliveryResultIdentifier.$variableData[self::VARIABLE_VALUE].$callId);
 
         return $variableData;
     }
@@ -503,7 +503,7 @@ class RdsResultStorage extends ConfigurableService
     {
         $variableData = $this->prepareVariableData($deliveryResultIdentifier, $test, $variable);
         $variableData[self::CALL_ID_TEST_COLUMN] = $callId;
-        $variableData[self::VARIABLE_HASH] = md5($deliveryResultIdentifier.$variableData[self::VARIABLE_VALUE].$callId);
+        $variableData[self::VARIABLE_HASH] = $deliveryResultIdentifier.md5($deliveryResultIdentifier.$variableData[self::VARIABLE_VALUE].$callId);
         return $variableData;
     }
 

--- a/scripts/install/createTables.php
+++ b/scripts/install/createTables.php
@@ -67,7 +67,7 @@ class createTables extends AbstractAction
             $tableVariables->addColumn(RdsResultStorage::VARIABLE_VALUE, 'text', ['notnull' => false]);
             $tableVariables->addColumn(RdsResultStorage::VARIABLE_IDENTIFIER, 'string', ['notnull' => false, 'length' => 255]);
             $tableVariables->addColumn(RdsResultStorage::VARIABLES_FK_COLUMN, 'string', ['length' => 255]);
-            $tableVariables->addColumn(RdsResultStorage::VARIABLE_HASH, 'string', ['length' => 128, 'notnull' => false]);
+            $tableVariables->addColumn(RdsResultStorage::VARIABLE_HASH, 'string', ['length' => 255, 'notnull' => false]);
 
             $tableVariables->setPrimaryKey([RdsResultStorage::VARIABLES_TABLE_ID]);
             $tableVariables->addForeignKeyConstraint(

--- a/scripts/install/createTables.php
+++ b/scripts/install/createTables.php
@@ -53,20 +53,22 @@ class createTables extends AbstractAction
             $tableVariables = $schema->createtable(RdsResultStorage::VARIABLES_TABLENAME);
             $tableVariables->addOption('engine', 'MyISAM');
 
-            $tableResults->addColumn(RdsResultStorage::RESULTS_TABLE_ID, "string", ["length" => 255]);
-            $tableResults->addColumn(RdsResultStorage::TEST_TAKER_COLUMN, "string", ["notnull" => false, "length" => 255]);
-            $tableResults->addColumn(RdsResultStorage::DELIVERY_COLUMN, "string", ["notnull" => false, "length" => 255]);
+            $tableResults->addColumn(RdsResultStorage::RESULTS_TABLE_ID, 'string', ['length' => 255]);
+            $tableResults->addColumn(RdsResultStorage::TEST_TAKER_COLUMN, 'string', ['notnull' => false, 'length' => 255]);
+            $tableResults->addColumn(RdsResultStorage::DELIVERY_COLUMN, 'string', ['notnull' => false, 'length' => 255]);
             $tableResults->setPrimaryKey([RdsResultStorage::RESULTS_TABLE_ID]);
 
 
-            $tableVariables->addColumn(RdsResultStorage::VARIABLES_TABLE_ID, "integer", ["autoincrement" => true]);
-            $tableVariables->addColumn(RdsResultStorage::CALL_ID_TEST_COLUMN, "string", ["notnull" => false, "length" => 255]);
-            $tableVariables->addColumn(RdsResultStorage::CALL_ID_ITEM_COLUMN, "string", ["notnull" => false, "length" => 255]);
-            $tableVariables->addColumn(RdsResultStorage::TEST_COLUMN, "string", ["notnull" => false, "length" => 255]);
-            $tableVariables->addColumn(RdsResultStorage::ITEM_COLUMN, "string", ["notnull" => false, "length" => 255]);
-            $tableVariables->addColumn(RdsResultStorage::VARIABLE_VALUE, "text", ["notnull" => false]);
-            $tableVariables->addColumn(RdsResultStorage::VARIABLE_IDENTIFIER, "string", ["notnull" => false, "length" => 255]);
-            $tableVariables->addColumn(RdsResultStorage::VARIABLES_FK_COLUMN, "string", ["length" => 255]);
+            $tableVariables->addColumn(RdsResultStorage::VARIABLES_TABLE_ID, 'integer', ['autoincrement' => true]);
+            $tableVariables->addColumn(RdsResultStorage::CALL_ID_TEST_COLUMN, 'string', ['notnull' => false, 'length' => 255]);
+            $tableVariables->addColumn(RdsResultStorage::CALL_ID_ITEM_COLUMN, 'string', ['notnull' => false, 'length' => 255]);
+            $tableVariables->addColumn(RdsResultStorage::TEST_COLUMN, 'string', ['notnull' => false, 'length' => 255]);
+            $tableVariables->addColumn(RdsResultStorage::ITEM_COLUMN, 'string', ['notnull' => false, 'length' => 255]);
+            $tableVariables->addColumn(RdsResultStorage::VARIABLE_VALUE, 'text', ['notnull' => false]);
+            $tableVariables->addColumn(RdsResultStorage::VARIABLE_IDENTIFIER, 'string', ['notnull' => false, 'length' => 255]);
+            $tableVariables->addColumn(RdsResultStorage::VARIABLES_FK_COLUMN, 'string', ['length' => 255]);
+            $tableVariables->addColumn(RdsResultStorage::VARIABLE_HASH, 'string', ['length' => 128, 'notnull' => false]);
+
             $tableVariables->setPrimaryKey([RdsResultStorage::VARIABLES_TABLE_ID]);
             $tableVariables->addForeignKeyConstraint(
                 $tableResults,
@@ -78,8 +80,7 @@ class createTables extends AbstractAction
             $tableVariables->addIndex([RdsResultStorage::CALL_ID_ITEM_COLUMN], RdsResultStorage::CALL_ID_ITEM_INDEX);
             $tableVariables->addIndex([RdsResultStorage::CALL_ID_TEST_COLUMN], RdsResultStorage::CALL_ID_TEST_INDEX);
             $tableVariables->addUniqueIndex([
-                RdsResultStorage::VARIABLES_FK_COLUMN,
-                RdsResultStorage::VARIABLE_VALUE,
+                RdsResultStorage::VARIABLE_HASH
             ], RdsResultStorage::UNIQUE_VARIABLE_INDEX);
 
         } catch (SchemaException $e) {

--- a/scripts/install/createTables.php
+++ b/scripts/install/createTables.php
@@ -42,6 +42,7 @@ class createTables extends AbstractAction
      */
     public function generateTables(\common_persistence_SqlPersistence $persistence)
     {
+        /** @var \common_persistence_sql_dbal_SchemaManager $schemaManager */
         $schemaManager = $persistence->getDriver()->getSchemaManager();
         $schema = $schemaManager->createSchema();
         $fromSchema = clone $schema;
@@ -52,30 +53,34 @@ class createTables extends AbstractAction
             $tableVariables = $schema->createtable(RdsResultStorage::VARIABLES_TABLENAME);
             $tableVariables->addOption('engine', 'MyISAM');
 
-            $tableResults->addColumn(RdsResultStorage::RESULTS_TABLE_ID, "string", array("length" => 255));
-            $tableResults->addColumn(RdsResultStorage::TEST_TAKER_COLUMN, "string", array("notnull" => false, "length" => 255));
-            $tableResults->addColumn(RdsResultStorage::DELIVERY_COLUMN, "string", array("notnull" => false, "length" => 255));
-            $tableResults->setPrimaryKey(array(RdsResultStorage::RESULTS_TABLE_ID));
+            $tableResults->addColumn(RdsResultStorage::RESULTS_TABLE_ID, "string", ["length" => 255]);
+            $tableResults->addColumn(RdsResultStorage::TEST_TAKER_COLUMN, "string", ["notnull" => false, "length" => 255]);
+            $tableResults->addColumn(RdsResultStorage::DELIVERY_COLUMN, "string", ["notnull" => false, "length" => 255]);
+            $tableResults->setPrimaryKey([RdsResultStorage::RESULTS_TABLE_ID]);
 
 
-            $tableVariables->addColumn(RdsResultStorage::VARIABLES_TABLE_ID, "integer", array("autoincrement" => true));
-            $tableVariables->addColumn(RdsResultStorage::CALL_ID_TEST_COLUMN, "string", array("notnull" => false, "length" => 255));
-            $tableVariables->addColumn(RdsResultStorage::CALL_ID_ITEM_COLUMN, "string", array("notnull" => false, "length" => 255));
-            $tableVariables->addColumn(RdsResultStorage::TEST_COLUMN, "string", array("notnull" => false, "length" => 255));
-            $tableVariables->addColumn(RdsResultStorage::ITEM_COLUMN, "string", array("notnull" => false, "length" => 255));
-            $tableVariables->addColumn(RdsResultStorage::VARIABLE_VALUE, "text", array("notnull" => false));
-            $tableVariables->addColumn(RdsResultStorage::VARIABLE_IDENTIFIER, "string", array("notnull" => false, "length" => 255));
-            $tableVariables->addColumn(RdsResultStorage::VARIABLES_FK_COLUMN, "string", array("length" => 255));
-            $tableVariables->setPrimaryKey(array(RdsResultStorage::VARIABLES_TABLE_ID));
+            $tableVariables->addColumn(RdsResultStorage::VARIABLES_TABLE_ID, "integer", ["autoincrement" => true]);
+            $tableVariables->addColumn(RdsResultStorage::CALL_ID_TEST_COLUMN, "string", ["notnull" => false, "length" => 255]);
+            $tableVariables->addColumn(RdsResultStorage::CALL_ID_ITEM_COLUMN, "string", ["notnull" => false, "length" => 255]);
+            $tableVariables->addColumn(RdsResultStorage::TEST_COLUMN, "string", ["notnull" => false, "length" => 255]);
+            $tableVariables->addColumn(RdsResultStorage::ITEM_COLUMN, "string", ["notnull" => false, "length" => 255]);
+            $tableVariables->addColumn(RdsResultStorage::VARIABLE_VALUE, "text", ["notnull" => false]);
+            $tableVariables->addColumn(RdsResultStorage::VARIABLE_IDENTIFIER, "string", ["notnull" => false, "length" => 255]);
+            $tableVariables->addColumn(RdsResultStorage::VARIABLES_FK_COLUMN, "string", ["length" => 255]);
+            $tableVariables->setPrimaryKey([RdsResultStorage::VARIABLES_TABLE_ID]);
             $tableVariables->addForeignKeyConstraint(
                 $tableResults,
-                array(RdsResultStorage::VARIABLES_FK_COLUMN),
-                array(RdsResultStorage::RESULTS_TABLE_ID),
-                array(),
+                [RdsResultStorage::VARIABLES_FK_COLUMN],
+                [RdsResultStorage::RESULTS_TABLE_ID],
+                [],
                 RdsResultStorage::VARIABLES_FK_NAME
             );
-            $tableVariables->addIndex(array(RdsResultStorage::CALL_ID_ITEM_COLUMN), RdsResultStorage::CALL_ID_ITEM_INDEX);
-            $tableVariables->addIndex(array(RdsResultStorage::CALL_ID_TEST_COLUMN), RdsResultStorage::CALL_ID_TEST_INDEX);
+            $tableVariables->addIndex([RdsResultStorage::CALL_ID_ITEM_COLUMN], RdsResultStorage::CALL_ID_ITEM_INDEX);
+            $tableVariables->addIndex([RdsResultStorage::CALL_ID_TEST_COLUMN], RdsResultStorage::CALL_ID_TEST_INDEX);
+            $tableVariables->addUniqueIndex([
+                RdsResultStorage::VARIABLES_FK_COLUMN,
+                RdsResultStorage::VARIABLE_VALUE,
+            ], RdsResultStorage::UNIQUE_VARIABLE_INDEX);
 
         } catch (SchemaException $e) {
             common_Logger::i('Database Schema already up to date.');

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -23,107 +23,108 @@ namespace oat\taoOutcomeRds\scripts\update;
 
 use oat\taoOutcomeRds\model\RdsResultStorage;
 use oat\tao\scripts\update\OntologyUpdater;
+use common_report_Report as Report;
 
 class Updater extends \common_ext_ExtensionUpdater
 {
 
-	/**
-     *
-     * @param string $currentVersion
-     * @return string $versionUpdatedTo
+    /**
+     * @param $initialVersion
+     * @return string|void
+     * @throws \common_Exception
      */
     public function update($initialVersion) {
 
         $currentVersion = $initialVersion;
-		if ($currentVersion == '1.0' || $currentVersion == '1.0.1' || $currentVersion == '1.0.2' ) {
-			$currentVersion = '1.0.3';
-		}
+        if ($currentVersion == '1.0' || $currentVersion == '1.0.1' || $currentVersion == '1.0.2' ) {
+            $currentVersion = '1.0.3';
+        }
 
-		if ($currentVersion == '1.0.3') {
+        if ($currentVersion == '1.0.3') {
 
-			//get variables
-			$persistence = \common_persistence_Manager::getPersistence('default');
-			$sql = 'SELECT * FROM ' . RdsResultStorage::VARIABLES_TABLENAME . ' WHERE '. RdsResultStorage::VARIABLE_VALUE .' IS NULL';
-			$countSql = 'SELECT count(*) FROM ' . RdsResultStorage::VARIABLES_TABLENAME . ' WHERE '. RdsResultStorage::VARIABLE_VALUE .' IS NULL';
+            //get variables
+            $persistence = \common_persistence_Manager::getPersistence('default');
+            $sql = 'SELECT * FROM ' . RdsResultStorage::VARIABLES_TABLENAME . ' WHERE '. RdsResultStorage::VARIABLE_VALUE .' IS NULL';
+            $countSql = 'SELECT count(*) FROM ' . RdsResultStorage::VARIABLES_TABLENAME . ' WHERE '. RdsResultStorage::VARIABLE_VALUE .' IS NULL';
 
-			//update variable storage table schema
-			$schema = $persistence->getDriver()->getSchemaManager()->createSchema();
-			$fromSchema = clone $schema;
+            //update variable storage table schema
+            $schema = $persistence->getDriver()->getSchemaManager()->createSchema();
+            $fromSchema = clone $schema;
 
-			$tableVariables = $schema->getTable(RdsResultStorage::VARIABLES_TABLENAME);
-			if(!$tableVariables->hasColumn(RdsResultStorage::VARIABLE_VALUE)){
-				$tableVariables->addColumn(RdsResultStorage::VARIABLE_VALUE, "text", array("notnull" => false));
-				$queries = $persistence->getPlatform()->getMigrateSchemaSql($fromSchema, $schema);
+            $tableVariables = $schema->getTable(RdsResultStorage::VARIABLES_TABLENAME);
+            if(!$tableVariables->hasColumn(RdsResultStorage::VARIABLE_VALUE)){
+                $tableVariables->addColumn(RdsResultStorage::VARIABLE_VALUE, "text", array("notnull" => false));
+                $queries = $persistence->getPlatform()->getMigrateSchemaSql($fromSchema, $schema);
 
-				foreach ($queries as $query) {
-					$persistence->exec($query);
-				}
+                foreach ($queries as $query) {
+                    $persistence->exec($query);
+                }
 
-				$sql = 'SELECT * FROM ' . RdsResultStorage::VARIABLES_TABLENAME;
-				$countSql = 'SELECT count(*) FROM ' . RdsResultStorage::VARIABLES_TABLENAME;
-			}
+                $sql = 'SELECT * FROM ' . RdsResultStorage::VARIABLES_TABLENAME;
+                $countSql = 'SELECT count(*) FROM ' . RdsResultStorage::VARIABLES_TABLENAME;
+            }
 
-			$params = array();
-			$entries = $persistence->query($countSql, $params)->fetchColumn();
+            $params = array();
+            $entries = $persistence->query($countSql, $params)->fetchColumn();
 
-			$limit = 1000;
-			for($i = 0; $i <= $entries; $i+=$limit){
-				$newSql = $sql . ' ORDER BY ' . RdsResultStorage::VARIABLES_TABLE_ID;
-				$query = $persistence->getPlatform()->limitStatement($newSql, $limit,$i);
-				$variables = $persistence->query($query);
+            $limit = 1000;
+            for($i = 0; $i <= $entries; $i+=$limit){
+                $newSql = $sql . ' ORDER BY ' . RdsResultStorage::VARIABLES_TABLE_ID;
+                $query = $persistence->getPlatform()->limitStatement($newSql, $limit,$i);
+                $variables = $persistence->query($query);
 
-				//store information the new way
-				foreach($variables as $variable){
-					//get Variable informations
-					$variableSql = 'SELECT * FROM ' . RdsResultStorage::RESULT_KEY_VALUE_TABLE_NAME . '
-				WHERE ' . RdsResultStorage::RESULTSKV_FK_COLUMN .' = ?';
-					$params = array($variable[RdsResultStorage::VARIABLES_TABLE_ID]);
-					$variableValues = $persistence->query($variableSql, $params);
+                //store information the new way
+                foreach($variables as $variable){
+                    //get Variable informations
+                    $variableSql = 'SELECT * FROM ' . RdsResultStorage::RESULT_KEY_VALUE_TABLE_NAME . '
+                WHERE ' . RdsResultStorage::RESULTSKV_FK_COLUMN .' = ?';
+                    $params = array($variable[RdsResultStorage::VARIABLES_TABLE_ID]);
+                    $variableValues = $persistence->query($variableSql, $params);
 
-					if (class_exists($variable[RdsResultStorage::VARIABLE_CLASS])) {
-						$resultVariable = new $variable[RdsResultStorage::VARIABLE_CLASS]();
-					} else {
-						$resultVariable = new \taoResultServer_models_classes_OutcomeVariable();
-					}
+                    if (class_exists($variable[RdsResultStorage::VARIABLE_CLASS])) {
+                        $resultVariable = new $variable[RdsResultStorage::VARIABLE_CLASS]();
+                    } else {
+                        $resultVariable = new \taoResultServer_models_classes_OutcomeVariable();
+                    }
 
-					foreach($variableValues as $variableValue){
-						$setter = 'set' . ucfirst($variableValue[RdsResultStorage::KEY_COLUMN]);
-						$value = $variableValue[RdsResultStorage::VALUE_COLUMN];
-						if (method_exists($resultVariable, $setter) && !is_null($value)) {
-							if ($variableValue[RdsResultStorage::KEY_COLUMN] == 'value' || $variableValue[RdsResultStorage::KEY_COLUMN] == 'candidateResponse') {
-								$value = base64_decode($value);
-							}
+                    foreach($variableValues as $variableValue){
+                        $setter = 'set' . ucfirst($variableValue[RdsResultStorage::KEY_COLUMN]);
+                        $value = $variableValue[RdsResultStorage::VALUE_COLUMN];
+                        if (method_exists($resultVariable, $setter) && !is_null($value)) {
+                            if ($variableValue[RdsResultStorage::KEY_COLUMN] == 'value' || $variableValue[RdsResultStorage::KEY_COLUMN] == 'candidateResponse') {
+                                $value = base64_decode($value);
+                            }
 
-							$resultVariable->$setter($value);
-						}
-					}
+                            $resultVariable->$setter($value);
+                        }
+                    }
 
-					$sqlUpdate = 'UPDATE ' . RdsResultStorage::VARIABLES_TABLENAME . ' SET ' . RdsResultStorage::VARIABLE_VALUE . ' = ? WHERE ' . RdsResultStorage::VARIABLES_TABLE_ID . ' = ?';
-					$paramsUpdate = array(serialize($resultVariable), $variable[RdsResultStorage::VARIABLES_TABLE_ID]);
-					$persistence->exec($sqlUpdate, $paramsUpdate);
+                    $sqlUpdate = 'UPDATE ' . RdsResultStorage::VARIABLES_TABLENAME . ' SET ' . RdsResultStorage::VARIABLE_VALUE . ' = ? WHERE ' . RdsResultStorage::VARIABLES_TABLE_ID . ' = ?';
+                    $paramsUpdate = array(serialize($resultVariable), $variable[RdsResultStorage::VARIABLES_TABLE_ID]);
+                    $persistence->exec($sqlUpdate, $paramsUpdate);
 
-				}
-			}
+                }
+            }
 
-			//remove kv table
-			$schema = $persistence->getDriver()->getSchemaManager()->createSchema();
-			$fromSchema = clone $schema;
+            //remove kv table
+            $schema = $persistence->getDriver()->getSchemaManager()->createSchema();
+            $fromSchema = clone $schema;
 
-			$tableVariables = $schema->getTable(RdsResultStorage::VARIABLES_TABLENAME);
-			$resultKv = $schema->dropTable(RdsResultStorage::RESULT_KEY_VALUE_TABLE_NAME);
-			$tableVariables->dropColumn(RdsResultStorage::VARIABLE_CLASS);
-			$queries = $persistence->getPlatform()->getMigrateSchemaSql($fromSchema, $schema);
-			foreach ($queries as $query) {
-				$persistence->exec($query);
-			}
+            $tableVariables = $schema->getTable(RdsResultStorage::VARIABLES_TABLENAME);
+            $resultKv = $schema->dropTable(RdsResultStorage::RESULT_KEY_VALUE_TABLE_NAME);
+            $tableVariables->dropColumn(RdsResultStorage::VARIABLE_CLASS);
+            $queries = $persistence->getPlatform()->getMigrateSchemaSql($fromSchema, $schema);
+            foreach ($queries as $query) {
+                $persistence->exec($query);
+            }
 
-			$currentVersion = '1.1.0';
-		}
-		$this->setVersion($currentVersion);
+            $currentVersion = '1.1.0';
+        }
+        $this->setVersion($currentVersion);
 
-		$this->skip('1.1.0', '2.1.0');
+        $this->skip('1.1.0', '2.1.0');
 
-		if ($this->isVersion('2.1.0')) {
+        if ($this->isVersion('2.1.0')) {
             OntologyUpdater::syncModels();
             $this->getServiceManager()->register(RdsResultStorage::SERVICE_ID, new RdsResultStorage([
                 RdsResultStorage::OPTION_PERSISTENCE => 'default'
@@ -131,6 +132,11 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.2.0');
         }
 
-		$this->skip('2.2.0','6.0.2');
-	}
+        $this->skip('2.2.0', '6.0.2');
+
+        if ($this->isVersion('6.0.2')) {
+            $this->addReport(new Report(Report::TYPE_WARNING, 'Run `\oat\taoOutcomeRds\scripts\update\dbMigrations\VariablesStorage_v1` migration script to move add unique index to variables storage.'));
+            $this->setVersion('6.1.0');
+        }
+    }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -149,7 +149,7 @@ class Updater extends \common_ext_ExtensionUpdater
 
             try {
                 $table = $schema->getTable(RdsResultStorage::VARIABLES_TABLENAME);
-                $table->addColumn(RdsResultStorage::VARIABLE_HASH, 'string', ['length' => 128, 'notnull' => false]);
+                $table->addColumn(RdsResultStorage::VARIABLE_HASH, 'string', ['length' => 255, 'notnull' => false]);
             } catch (SchemaException $e) {
                 \common_Logger::i('Database schema of RdsResultStorage service is already up to date.');
             }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -135,7 +135,7 @@ class Updater extends \common_ext_ExtensionUpdater
         $this->skip('2.2.0', '6.0.2');
 
         if ($this->isVersion('6.0.2')) {
-            $this->addReport(new Report(Report::TYPE_WARNING, 'Run `\oat\taoOutcomeRds\scripts\update\dbMigrations\VariablesStorage_v1` migration script to move add unique index to variables storage.'));
+            $this->addReport(new Report(Report::TYPE_WARNING, 'Run `\oat\taoOutcomeRds\scripts\update\dbMigrations\v6_1_0\VariablesStorage_v1` migration script to move add unique index to variables storage.'));
             $this->setVersion('6.1.0');
         }
     }

--- a/scripts/update/dbMigrations/VariablesStorage_v1.php
+++ b/scripts/update/dbMigrations/VariablesStorage_v1.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019  (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoOutcomeRds\scripts\update\dbMigrations;
+
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\extension\AbstractAction;
+use oat\taoOutcomeRds\model\RdsResultStorage;
+
+/**
+ * Class VariablesStorage_v1
+ *
+ * NOTE! Do not change this file. If you need to change schema of storage create new version of this class.
+ *
+ * @package oat\taoOutcomeRds\scripts\update\dbMigrations
+ * @author Aleh Hutnikau, <hutnikau@1pt.com>
+ */
+class VariablesStorage_v1 extends AbstractAction
+{
+
+    /**
+     * @param $params
+     * @return \common_report_Report
+     * @throws \common_Exception
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
+     */
+    public function __invoke($params)
+    {
+        /** @var RdsResultStorage $service */
+        $service = $this->getServiceManager()->get(RdsResultStorage::SERVICE_ID);
+        $persistence = $service->getPersistence();
+        $this->alterTable($persistence);
+        $this->updateData($persistence);
+
+        return \common_report_Report::createSuccess('RDS variables storage was successfully migrated to v1');
+    }
+
+    /**
+     * Update table in database
+     * @param \common_persistence_SqlPersistence $persistence
+     */
+    protected function alterTable(\common_persistence_SqlPersistence $persistence)
+    {
+        /** @var AbstractSchemaManager $schemaManager */
+        $schemaManager = $persistence->getDriver()->getSchemaManager();
+
+        /** @var Schema $schema */
+        $schema = $schemaManager->createSchema();
+        $fromSchema = clone $schema;
+
+        try {
+            $table = $schema->getTable(RdsResultStorage::VARIABLES_TABLENAME);
+            $table->addColumn(RdsResultStorage::VARIABLE_HASH, 'string', ['length' => 128, 'notnull' => false]);
+            $table->addUniqueIndex([RdsResultStorage::VARIABLE_HASH], RdsResultStorage::UNIQUE_VARIABLE_INDEX);
+        } catch (SchemaException $e) {
+            \common_Logger::i('Database Schema of TransmissionLog service is already up to date.');
+        }
+
+        $queries = $persistence->getPlatForm()->getMigrateSchemaSql($fromSchema, $schema);
+
+        foreach ($queries as $query) {
+            $persistence->exec($query);
+        }
+    }
+
+    /**
+     * Create table in database
+     * @param \common_persistence_SqlPersistence $persistence
+     */
+    protected function updateData(\common_persistence_SqlPersistence $persistence)
+    {
+        $persistence->exec('UPDATE variables_storage SET variable_hash=MD5(concat(results_result_id,value,call_id_test))
+            WHERE call_id_test IS NOT NULL');
+        $persistence->exec('UPDATE variables_storage SET variable_hash=MD5(concat(results_result_id,value,call_id_item))
+            WHERE call_id_item IS NOT NULL');
+    }
+}

--- a/scripts/update/dbMigrations/VariablesStorage_v1.php
+++ b/scripts/update/dbMigrations/VariablesStorage_v1.php
@@ -72,7 +72,7 @@ class VariablesStorage_v1 extends AbstractAction
             $table->addColumn(RdsResultStorage::VARIABLE_HASH, 'string', ['length' => 128, 'notnull' => false]);
             $table->addUniqueIndex([RdsResultStorage::VARIABLE_HASH], RdsResultStorage::UNIQUE_VARIABLE_INDEX);
         } catch (SchemaException $e) {
-            \common_Logger::i('Database Schema of TransmissionLog service is already up to date.');
+            \common_Logger::i('Database schema of RdsResultStorage service is already up to date.');
         }
 
         $queries = $persistence->getPlatForm()->getMigrateSchemaSql($fromSchema, $schema);

--- a/scripts/update/dbMigrations/v6_1_0/VariablesStorage_v1.php
+++ b/scripts/update/dbMigrations/v6_1_0/VariablesStorage_v1.php
@@ -18,7 +18,7 @@
  *
  */
 
-namespace oat\taoOutcomeRds\scripts\update\dbMigrations;
+namespace oat\taoOutcomeRds\scripts\update\dbMigrations\v6_1_0;
 
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\SchemaException;

--- a/scripts/update/dbMigrations/v6_1_0/VariablesStorage_v1.php
+++ b/scripts/update/dbMigrations/v6_1_0/VariablesStorage_v1.php
@@ -87,9 +87,9 @@ class VariablesStorage_v1 extends AbstractAction
      */
     protected function updateData(\common_persistence_SqlPersistence $persistence)
     {
-        $persistence->exec('UPDATE variables_storage SET variable_hash=MD5(concat(results_result_id,value,call_id_test))
+        $persistence->exec('UPDATE variables_storage SET variable_hash=concat(results_result_id,MD5(concat(results_result_id,value,call_id_test)))
             WHERE call_id_test IS NOT NULL');
-        $persistence->exec('UPDATE variables_storage SET variable_hash=MD5(concat(results_result_id,value,call_id_item))
+        $persistence->exec('UPDATE variables_storage SET variable_hash=concat(results_result_id,MD5(concat(results_result_id,value,call_id_item)))
             WHERE call_id_item IS NOT NULL');
     }
 }

--- a/scripts/update/dbMigrations/v6_1_0/VariablesStorage_v1.php
+++ b/scripts/update/dbMigrations/v6_1_0/VariablesStorage_v1.php
@@ -69,7 +69,6 @@ class VariablesStorage_v1 extends AbstractAction
 
         try {
             $table = $schema->getTable(RdsResultStorage::VARIABLES_TABLENAME);
-            $table->addColumn(RdsResultStorage::VARIABLE_HASH, 'string', ['length' => 128, 'notnull' => false]);
             $table->addUniqueIndex([RdsResultStorage::VARIABLE_HASH], RdsResultStorage::UNIQUE_VARIABLE_INDEX);
         } catch (SchemaException $e) {
             \common_Logger::i('Database schema of RdsResultStorage service is already up to date.');


### PR DESCRIPTION
*Purpose:* avoid duplicated in results storage.
*Implementation:* add unique constraint to variables storage

Made a performance test with/without that unique index:
Env: https://act-test.taocloud.org
Users: 100
Ramp-up: 10 sec
Test size: 8 items
table size: 5,607,787 records

The difference is no more than 3% which is within the margin of error:
No index:
![act_test_no_index_3](https://user-images.githubusercontent.com/11025793/62283129-85b79200-b459-11e9-9ccd-1cb41c67fa19.PNG)

With index:
![act_test_with_index_2](https://user-images.githubusercontent.com/11025793/62283165-96680800-b459-11e9-835d-1f243c73b919.PNG)

