### PR TITLE
Fix/tao 8930/result export missing records

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label' => 'extension-tao-outcomerds',
     'description' => 'extension that allows a storage in relational database',
     'license' => 'GPL-2.0',
-    'version' => '6.1.1',
+    'version' => '6.1.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoResultServer' => '>=9.3.0',

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -371,9 +371,13 @@ class RdsResultStorage extends ConfigurableService
         $qb = $this->getQueryBuilder()
             ->select('*')
             ->from(self::RESULTS_TABLENAME)
-            ->orderBy($this->getOrderField($options), $this->getOrderDirection($options))
-            ->setMaxResults(isset($options['limit']) ? $options['limit'] : 1000)
-            ->setFirstResult(isset($options['offset']) ? $options['offset'] : 0);
+            ->orderBy($this->getOrderField($options), $this->getOrderDirection($options));
+
+        if (isset($options['offset']) || isset($options['limit'])) {
+            $qb
+                ->setMaxResults(isset($options['limit']) ? $options['limit'] : 1000)
+                ->setFirstResult(isset($options['offset']) ? $options['offset'] : 0);
+        }
 
         if (count($delivery) > 0) {
             $qb

--- a/model/RdsResultStorage.php
+++ b/model/RdsResultStorage.php
@@ -373,10 +373,11 @@ class RdsResultStorage extends ConfigurableService
             ->from(self::RESULTS_TABLENAME)
             ->orderBy($this->getOrderField($options), $this->getOrderDirection($options));
 
-        if (isset($options['offset']) || isset($options['limit'])) {
-            $qb
-                ->setMaxResults(isset($options['limit']) ? $options['limit'] : 1000)
-                ->setFirstResult(isset($options['offset']) ? $options['offset'] : 0);
+        if (isset($options['offset'])) {
+            $qb->setFirstResult($options['offset']);
+        }
+        if (isset($options['limit'])) {
+            $qb->setMaxResults($options['limit']);
         }
 
         if (count($delivery) > 0) {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -163,6 +163,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.1.0');
         }
 
-        $this->skip('6.1.0', '6.1.1');
+        $this->skip('6.1.0', '6.1.2');
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8930

Fix for a regression from https://github.com/oat-sa/extension-tao-outcomerds/pull/89
A default value for `limit` and `offset` should not be added every time. This caused the results export to only preview/export first 1000 results.
The solution is to only set these values when they are supplied through `$options`.

In order to test the correct behavior the environment should have more than 1000 results for a delivery, going to `Results -> Export Table` would show only 40 pages, and filtering for latest delivery executions would return empty or incomplete list. With the fix applied all records should be accessible.
