### PR TITLE
Fix/nex 336/schema change action abstraction

### DIFF
--- a/scripts/SchemaChange/ResultStorageSchemaChangeAction.php
+++ b/scripts/SchemaChange/ResultStorageSchemaChangeAction.php
@@ -14,21 +14,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
- *
+ * Copyright (c) 2019 Open Assessment Technologies SA
  */
 
 namespace oat\taoOutcomeRds\scripts\SchemaChange;
 
-use common_Logger as Logger;
-use common_persistence_Persistence as Persistence;
-use common_report_Report as Report;
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Schema\SchemaException;
-use oat\generis\persistence\PersistenceManager;
-use oat\oatbox\extension\AbstractAction;
 use oat\taoOutcomeRds\model\AbstractRdsResultStorage;
 
 abstract class ResultStorageSchemaChangeAction extends SchemaChangeAction

--- a/scripts/SchemaChange/ResultStorageSchemaChangeAction.php
+++ b/scripts/SchemaChange/ResultStorageSchemaChangeAction.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ *
+ */
+
+namespace oat\taoOutcomeRds\scripts\SchemaChange;
+
+use common_Logger as Logger;
+use common_persistence_Persistence as Persistence;
+use common_report_Report as Report;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
+use oat\generis\persistence\PersistenceManager;
+use oat\oatbox\extension\AbstractAction;
+use oat\taoOutcomeRds\model\AbstractRdsResultStorage;
+
+abstract class ResultStorageSchemaChangeAction extends SchemaChangeAction
+{
+    /** @var AbstractRdsResultStorage */
+    protected $resultStorage;
+
+    /**
+     * @inheritdoc
+     * Gets the persistence.
+     */
+    protected function beforeChange()
+    {
+        $this->resultStorage = $this->getServiceLocator()->get(AbstractRdsResultStorage::SERVICE_ID);
+        return $this->resultStorage->getPersistence();
+    }
+}

--- a/scripts/SchemaChange/SchemaChangeAction.php
+++ b/scripts/SchemaChange/SchemaChangeAction.php
@@ -29,7 +29,6 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
 use oat\generis\persistence\PersistenceManager;
 use oat\oatbox\extension\AbstractAction;
-use oat\taoOutcomeRds\model\AbstractRdsResultStorage;
 
 abstract class SchemaChangeAction extends AbstractAction
 {
@@ -42,10 +41,6 @@ abstract class SchemaChangeAction extends AbstractAction
      * @param $params
      *
      * @return Report
-     * @throws \common_exception_InconsistentData
-     * @throws \common_ext_ExtensionException
-     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
-     * @throws DBALException
      */
     public function __invoke($params)
     {
@@ -74,6 +69,7 @@ abstract class SchemaChangeAction extends AbstractAction
     /**
      * Actions to be done before schema change.
      * This must return the persistence
+     *
      * @return Persistence
      */
     protected function beforeChange()

--- a/scripts/SchemaChange/SchemaChangeAction.php
+++ b/scripts/SchemaChange/SchemaChangeAction.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ *
+ */
+
+namespace oat\taoOutcomeRds\scripts\SchemaChange;
+
+use common_Logger as Logger;
+use common_persistence_Persistence as Persistence;
+use common_report_Report as Report;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
+use oat\generis\persistence\PersistenceManager;
+use oat\oatbox\extension\AbstractAction;
+use oat\taoOutcomeRds\model\AbstractRdsResultStorage;
+
+abstract class SchemaChangeAction extends AbstractAction
+{
+    const ACTION_NAME = '';
+
+    /** @var Persistence */
+    protected $persistence;
+
+    /**
+     * @param $params
+     *
+     * @return Report
+     * @throws \common_exception_InconsistentData
+     * @throws \common_ext_ExtensionException
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
+     * @throws DBALException
+     */
+    public function __invoke($params)
+    {
+        $this->persistence = $this->beforeChange();
+
+        $oldSchema = $this->readSchema();
+        $newSchema = clone $oldSchema;
+        try {
+            $report = $this->changeSchema($newSchema);
+        } catch (SchemaException $exception) {
+            return Report::createFailure($exception->getMessage());
+        }
+
+        try {
+            $this->writeSchema($oldSchema, $newSchema);
+        } catch (DBALException $e) {
+            Logger::w($e->getMessage());
+            return Report::createFailure(__('Something went wrong during ' . $this->getActionName()));
+        }
+
+        $this->afterChange();
+
+        return $report;
+    }
+
+    /**
+     * Actions to be done before schema change.
+     * This must return the persistence
+     * @return Persistence
+     */
+    protected function beforeChange()
+    {
+        return $this->getServiceLocator()->get(PersistenceManager::SERVICE_ID)->getPersistenceById('default');
+    }
+
+    /**
+     * Reads schema from persistence.
+     *
+     * @return Schema
+     */
+    private function readSchema()
+    {
+        /** @var \common_persistence_sql_dbal_SchemaManager $schemaManager */
+        $schemaManager = $this->persistence->getDriver()->getSchemaManager();
+        return $schemaManager->createSchema();
+    }
+
+    /**
+     * Performs the schema changes.
+     *
+     * @param Schema $schema
+     *
+     * @throws SchemaChangeException
+     */
+    abstract protected function changeSchema(Schema $schema);
+
+    /**
+     * Write new schema to persistence.
+     *
+     * @param Schema $oldSchema
+     * @param Schema $newSchema
+     *
+     * @throws DBALException
+     */
+    private function writeSchema(Schema $oldSchema, Schema $newSchema)
+    {
+        $queries = $this->persistence->getPlatform()->getMigrateSchemaSql($oldSchema, $newSchema);
+        foreach ($queries as $query) {
+            $this->persistence->exec($query);
+        }
+    }
+
+    /**
+     * Actions to be done after successful schema change.
+     */
+    protected function afterChange()
+    {
+    }
+
+    protected function getActionName()
+    {
+        return static::ACTION_NAME;
+    }
+}

--- a/scripts/SchemaChange/SchemaChangeException.php
+++ b/scripts/SchemaChange/SchemaChangeException.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ *
+ */
+
+namespace oat\taoOutcomeRds\scripts\SchemaChange;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+class SchemaChangeException extends SchemaException
+{
+}

--- a/scripts/SchemaChange/SchemaChangeException.php
+++ b/scripts/SchemaChange/SchemaChangeException.php
@@ -14,9 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
- *
+ * Copyright (c) 2019 Open Assessment Technologies SA
  */
 
 namespace oat\taoOutcomeRds\scripts\SchemaChange;

--- a/scripts/uninstall/removeTables.php
+++ b/scripts/uninstall/removeTables.php
@@ -14,14 +14,13 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
- *
+ * Copyright (c) 2014-2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
 namespace oat\taoOutcomeRds\scripts\uninstall;
 
 use common_ext_ExtensionsManager as ExtensionsManager;
+use common_report_Report as Report;
 use Doctrine\DBAL\Schema\Schema;
 use oat\generis\model\data\ModelManager;
 use oat\tao\model\extension\ExtensionModel;
@@ -39,6 +38,8 @@ class removeTables extends ResultStorageSchemaChangeAction
     {
         $schema->dropTable($this->resultStorage::VARIABLES_TABLENAME);
         $schema->dropTable($this->resultStorage::RESULTS_TABLENAME);
+
+        return Report::createSuccess(__('2 tables removed.'));
     }
 
     /**


### PR DESCRIPTION
This PR aims at proposing an abstraction for schema modification actions.
It has two levels of abstraction:
- *SchemaChangeAction* : provides base template function: retrieving current schema, calling the changes, persist changes, error handling and returning report.
- *ResultStorageSchemaChangeAction* : provides ResultStorage specific abstraction (persistence if provided by ResultStorage itslef), allowing an easy schema change.