### PR TITLE
Moving from PHP serialized variables to JSON encoded variables

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,10 +25,10 @@ return [
     'label' => 'extension-tao-outcomerds',
     'description' => 'extension that allows a storage in relational database',
     'license' => 'GPL-2.0',
-    'version' => '6.4.0',
+    'version' => '7.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
-        'taoResultServer' => '>=9.3.0',
+        'taoResultServer' => '>=10.5.0',
         'generis' => '>=12.15.0'
     ],
     // for compatibility

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return [
     'version' => '7.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
-        'taoResultServer' => '>=10.5.0',
+        'taoResultServer' => '>=11.0.0',
         'generis' => '>=12.15.0'
     ],
     // for compatibility

--- a/model/AbstractRdsResultStorage.php
+++ b/model/AbstractRdsResultStorage.php
@@ -632,12 +632,6 @@ abstract class AbstractRdsResultStorage extends ConfigurableService implements W
      */
     protected function serializeVariableValue($value)
     {
-        $serializedValue = json_decode(json_encode($value), true);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \LogicException('JSON encoding error: ' . json_last_error());
-        }
-
         if (!$value instanceof \taoResultServer_models_classes_Variable) {
             throw new \LogicException(
                 sprintf(
@@ -648,7 +642,7 @@ abstract class AbstractRdsResultStorage extends ConfigurableService implements W
             );
         }
 
-        return json_encode($serializedValue);
+        return json_encode($value);
     }
 
     /**

--- a/model/AbstractRdsResultStorage.php
+++ b/model/AbstractRdsResultStorage.php
@@ -638,24 +638,14 @@ abstract class AbstractRdsResultStorage extends ConfigurableService implements W
             throw new \LogicException('JSON encoding error: ' . json_last_error());
         }
 
-        switch ($value) {
-            case $value instanceof \taoResultServer_models_classes_ResponseVariable:
-                $serializedValue['type'] = \taoResultServer_models_classes_ResponseVariable::class;
-                break;
-            case $value instanceof \taoResultServer_models_classes_OutcomeVariable:
-                $serializedValue['type'] = \taoResultServer_models_classes_OutcomeVariable::class;
-                break;
-            case $value instanceof \taoResultServer_models_classes_TraceVariable:
-                $serializedValue['type'] = \taoResultServer_models_classes_TraceVariable::class;
-                break;
-            default:
-                throw new \LogicException(
-                    sprintf(
-                        "Value cannot be serialized. Expected instance of '%s', '%s' received.",
-                        \taoResultServer_models_classes_Variable::class,
-                        gettype($value)
-                    )
-                );
+        if (!$value instanceof \taoResultServer_models_classes_Variable) {
+            throw new \LogicException(
+                sprintf(
+                    "Value cannot be serialized. Expected instance of '%s', '%s' received.",
+                    \taoResultServer_models_classes_Variable::class,
+                    gettype($value)
+                )
+            );
         }
 
         return json_encode($serializedValue);

--- a/model/AbstractRdsResultStorage.php
+++ b/model/AbstractRdsResultStorage.php
@@ -633,21 +633,32 @@ abstract class AbstractRdsResultStorage extends ConfigurableService implements W
     protected function serializeVariableValue($value)
     {
         $serializedValue = json_decode(json_encode($value), true);
-        if (!$value instanceof \taoResultServer_models_classes_Variable) {
-            throw new \LogicException(sprintf(
-                    "Value cannot be serialized. Expected instance of '%s', '%s' received.",
-                    \taoResultServer_models_classes_Variable::class,
-                    gettype($value)
-                )
-            );
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \LogicException('JSON encoding error: ' . json_last_error());
         }
+
         switch ($value) {
             case $value instanceof \taoResultServer_models_classes_ResponseVariable:
+                $serializedValue['type'] = \taoResultServer_models_classes_ResponseVariable::class;
                 break;
+            case $value instanceof \taoResultServer_models_classes_OutcomeVariable:
+                $serializedValue['type'] = \taoResultServer_models_classes_OutcomeVariable::class;
+                break;
+            case $value instanceof \taoResultServer_models_classes_TraceVariable:
+                $serializedValue['type'] = \taoResultServer_models_classes_TraceVariable::class;
+                break;
+            default:
+                throw new \LogicException(
+                    sprintf(
+                        "Value cannot be serialized. Expected instance of '%s', '%s' received.",
+                        \taoResultServer_models_classes_Variable::class,
+                        gettype($value)
+                    )
+                );
         }
-        $serializedValue['type'] = get_class($value);
 
-        return $serializedValue;
+        return json_encode($serializedValue);
     }
 
     /**

--- a/scripts/tools/KvToRdsMigration.php
+++ b/scripts/tools/KvToRdsMigration.php
@@ -44,7 +44,7 @@ class KvToRdsMigration extends ScriptAction
     /** @var \taoResultServer_models_classes_ReadableResultStorage $kvStorageService */
     protected $kvStorage;
 
-    /** @var array  */
+    /** @var array */
     protected $deliveryExecutions = [];
 
     /** @var \common_report_Report */
@@ -65,7 +65,7 @@ class KvToRdsMigration extends ScriptAction
                 'default' => true,
                 'flag' => true,
                 'description' => 'Apply the migration to Result storage.',
-            ]
+            ],
         ];
     }
 
@@ -101,6 +101,7 @@ class KvToRdsMigration extends ScriptAction
                 'The migration has not been applied because of dryrun mode. Use --wet-run to really run the migration'
             ));
         }
+
         return $this->report;
     }
 
@@ -113,6 +114,7 @@ class KvToRdsMigration extends ScriptAction
      *
      * @param $callId
      * @param array $variables
+     *
      * @throws \common_exception_Error
      */
     protected function migrateDeliveryExecution($callId, array $variables)
@@ -145,6 +147,7 @@ class KvToRdsMigration extends ScriptAction
      * @param $callId
      * @param $deliveryExecutionIdentifier
      * @param array $variables
+     *
      * @return \common_report_Report
      */
     protected function migrateDeliveryExecutionVariables($callId, $deliveryExecutionIdentifier, array $variables)
@@ -153,10 +156,10 @@ class KvToRdsMigration extends ScriptAction
         $identifier = null;
 
         foreach ($variables as $variable) {
-            $identifier = $variable->variable->identifier;
+            $identifier = $variable->variable->getIdentifier();
 
-            foreach ($this->rdsStorage->getVariable($callId, $variable->variable->identifier) as $existingVariable) {
-                if ($variable->variable->epoch == $existingVariable->variable->epoch) {
+            foreach ($this->rdsStorage->getVariable($callId, $variable->variable->getIdentifier()) as $existingVariable) {
+                if ($variable->variable->getEpoch() == $existingVariable->variable->getEpoch()) {
                     continue 2;
                 }
             }
@@ -184,7 +187,7 @@ class KvToRdsMigration extends ScriptAction
         if ($count == 0) {
             $message = 'Already migrated.';
         } else {
-            $message =  $count . ' variables migrated';
+            $message = $count . ' variables migrated';
         }
 
         return \common_report_Report::createInfo('Migrating ' . $callId . ' : ' . $identifier . ' : ' . $message);
@@ -204,6 +207,7 @@ class KvToRdsMigration extends ScriptAction
         if ($resultStorageKey != 'taoAltResultStorage/KeyValueResultStorage') {
             throw new \common_Exception('Result storage is not on KeyValue storage mode.');
         }
+
         return $resultService->instantiateResultStorage($resultStorageKey);
     }
 
@@ -244,7 +248,7 @@ class KvToRdsMigration extends ScriptAction
         return [
             'prefix' => 'h',
             'longPrefix' => 'help',
-            'description' => 'Prints a help statement'
+            'description' => 'Prints a help statement',
         ];
     }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -163,6 +163,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.1.0');
         }
 
-        $this->skip('6.1.0', '6.4.0');
+        $this->skip('6.1.0', '7.0.0');
     }
 }


### PR DESCRIPTION
This PR depends on https://github.com/oat-sa/extension-tao-outcome/pull/176/files

Storing outcome, response and trace variables as JSON strings instead of PHP serialized objects in the database is the first step in the process of having an ETL solution on top of TAO for easy data extraction.

This implementation is meant to be a backward compatible change, meaning that if the attempt of json decoding the raw variable fails, it will fall back to the original object unserialization. 